### PR TITLE
Fix issue #10 fix navbar for mobile

### DIFF
--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -3,8 +3,8 @@
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
-  <div class="collapse navbar-collapse d-flex flex-row-reverse" id="navbarNavDropdown">
-    <ul class="navbar-nav">
+  <div class="collapse justify-content-end navbar-collapse" id="navbarNavDropdown">
+    <ul class="navbar-nav text-right text-lg-left">
       <li class="nav-item active">
         <a class="nav-link" href="/">Home <span class="sr-only">(current)</span></a>
       </li>


### PR DESCRIPTION
Remove `display: flex;` property, because it kept the navbar from hidding.
Instead of sending elements to the right with flex use `text-align:
right;` to do it.
Also reset elements to the end on desktop with `justify-content:
flex-end;`